### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Key names constructed from uppercase values, `-`, `+` and `.` substituted with `
 
 Install local
 
-    npm install http-headers-ts --save
+    npm install http-constants-ts --save
 
 Available at the moment
 


### PR DESCRIPTION
Corrected the installation instruction in the `README`.

Fixed https://github.com/iDschepe/http-constants-ts/issues/1